### PR TITLE
Adding support for new VERSION files

### DIFF
--- a/pmm-info.sh
+++ b/pmm-info.sh
@@ -33,8 +33,8 @@ echo '==================== PMM list (sudo pmm-admin list):'
 sudo pmm-admin list 2>&1 | grep -v '^$' | sed 's|^|  |'
 
 if [ "$1" != "" ]; then
-  echo '==================== Extended info: cat /opt/VERSION inside docker container:'
-  sudo docker exec -it $(sudo docker ps -a | grep pmm | grep 'Up.*pmm-server' | sed 's|[ \t].*||') cat /opt/VERSION 2>&1 | grep -v '^$' | sed 's|^|  |'
+  echo '==================== Extended info: cat /opt/.../VERSION inside docker container:'
+  sudo docker exec -it $(sudo docker ps -a | grep pmm | grep 'Up.*pmm-server' | sed 's|[ \t].*||') find /opt/ -name VERSION -exec echo {} \; -exec cat {} \; 2>&1 | grep -v '^$' | sed 's|^|  |'
   echo '==================== Extended info: cat /var/log/nginx/error.log inside docker container:'
   sudo docker exec -it $(sudo docker ps -a | grep pmm | grep 'Up.*pmm-server' | sed 's|[ \t].*||') cat /var/log/nginx/error.log 2>&1 | grep -v '^$' | sed 's|^|  |'
   echo '==================== Extended info: cat /var/log/consul.log inside docker container:'


### PR DESCRIPTION
Since 1.1.1 other VERSION files are used. Still, this will
work with older /opt/VERSION file, too, and will add others.

From 1.1.1 container:
```
  /opt/grafana-dashboards/VERSION
  1.1.1
  /opt/prometheus/data/VERSION
  1
```

From 1.0.7 container:
```
  /opt/prometheus/data/VERSION
  1
  /opt/VERSION
  1.0.7
```

Current code is failing with 1.1.1 version:
```
==================== Extended info: cat /opt/VERSION inside docker container:
  cat: /opt/VERSION: No such file or directory
```